### PR TITLE
create script to generate .tar of arbitrary size

### DIFF
--- a/scripts/create_tarball.py
+++ b/scripts/create_tarball.py
@@ -1,0 +1,28 @@
+import shutil
+import os
+import tarfile
+
+def mktar(seed_file_path="../static/harambe.jpg", target_file_path="../static/arch.tar", target_size=1):
+    target_bytes = target_size * (1024 ** 3)
+    seed_bytes = os.path.getsize(seed_file_path)
+    iterations = int(target_bytes/seed_bytes)
+    file_list = []
+
+    if not os.path.exists("working/"):
+        os.mkdir("working/")
+
+    for i in range(1,iterations):
+        iterfile = "working/h"+str(i)+".jpg"
+        shutil.copyfile(seed_file_path,iterfile)
+        file_list.append(iterfile)
+
+    tar = tarfile.open(target_file_path,"w")
+    for name in file_list:
+        tar.add(name)
+    tar.close()
+
+    for i in file_list:
+        os.remove(i)
+
+    os.rmdir("working/")
+    print("done!")


### PR DESCRIPTION
give it a run on your machines to make sure it works. I was doing:

python3
import create_tarball as ct
ct.mktar()

there are parameters to change filename, seed file and size but they have default values so you can just call it to make a 1gb archive. for some reason ubuntu shows this as 1.1 but it's 1.01; I think it's using 1000 istead of 1024